### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ Image,
 const Captcha = require("2captcha")
 const fs = require("fs")
 
-const solver = new Captcha.solver("<Your 2captcha api key>")
+const solver = new Captcha.Solver("<Your 2captcha api key>")
 
 // Read from a file as base64 text
 solver.imageCaptcha(fs.readFileSync("./captcha.png", "base64"))


### PR DESCRIPTION
In the base64 example, "solver" is "Solver" (there is a misspell on the first s, it should be capital)