### PR TITLE
fix: add missing fields to hcaptcha options

### DIFF
--- a/src/structs/2captcha.ts
+++ b/src/structs/2captcha.ts
@@ -23,7 +23,11 @@ interface UserHCaptchaExtra extends BaseSolve {
     header_acao?: boolean,
     pingback?: string,
     proxy?: string,
-    proxytype?: string
+    proxytype?: string,
+    invisible?: 0 | 1,
+    data?: string,
+    userAgent?: string,
+    soft_id?: number;
 }
 
 interface UserImageCaptchaExtra extends BaseSolve {


### PR DESCRIPTION
Previously hcaptcha options were missing several non-required fields like "userAgent" and "invisible".  This pr just adds some missing fields from [the 2captcha documentation](https://2captcha.com/2captcha-api#solving_hcaptcha).