### PR TITLE
removed action get from in.php requests

### DIFF
--- a/src/structs/2captcha.ts
+++ b/src/structs/2captcha.ts
@@ -172,7 +172,6 @@ export class Solver {
         const payload = {
             invisible: false,
             header_acao: false,
-            action: "get",
             ...extra,
             googlekey: googlekey,
             pageurl: pageurl,
@@ -217,7 +216,6 @@ export class Solver {
         const payload = {
             invisible: false,
             header_acao: false,
-            action: "get",
             ...extra,
             sitekey: sitekey,
             pageurl: pageurl,


### PR DESCRIPTION
`recaptcha` and `hcaptcha` methods contained `action: "get"` in the payload by default which is incorrect as the action parameter is optional.
The action value should be passed as `extra.action` with no default value.